### PR TITLE
Thread-safe JWT refresh

### DIFF
--- a/DanXi.xcodeproj/project.pbxproj
+++ b/DanXi.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		F15059FD2BBD60F200EA62E3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F15059FC2BBD60F200EA62E3 /* PrivacyInfo.xcprivacy */; };
 		F1728E342BB1661C00483F09 /* SheetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1728E332BB1661C00483F09 /* SheetExtension.swift */; };
 		F1A762D62BAFD1B7001E5D08 /* IntroSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A762D52BAFD1B7001E5D08 /* IntroSheet.swift */; };
+		F1B1DF782BC19FC4005E8F87 /* Queue in Frameworks */ = {isa = PBXBuildFile; productRef = F1B1DF772BC19FC4005E8F87 /* Queue */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -346,6 +347,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1B1DF782BC19FC4005E8F87 /* Queue in Frameworks */,
 				27BBBD05291193D2007C2905 /* CachedAsyncImage in Frameworks */,
 				27A308C729A6753B00E8F646 /* SwiftyJSON in Frameworks */,
 				270CD1942BAD697600881ABA /* ViewUtils in Frameworks */,
@@ -755,6 +757,7 @@
 				270CD1932BAD697600881ABA /* ViewUtils */,
 				27C68CB22BB563EE00037D52 /* Utils */,
 				27D3A4952BBC844200350D21 /* CampusUI */,
+				F1B1DF772BC19FC4005E8F87 /* Queue */,
 			);
 			productName = "DanXi-native";
 			productReference = 8AC7A5CD26872C3E00C9CD98 /* DanXi.app */;
@@ -802,6 +805,7 @@
 				27A5DA1C29D6D51E0042D28D /* XCRemoteSwiftPackageReference "advanced-scrollview" */,
 				27C9160D2AB0AB38000E561A /* XCRemoteSwiftPackageReference "LaTeXSwiftUI" */,
 				27D1D6462AB5F93C00E8D536 /* XCRemoteSwiftPackageReference "BetterSafariView" */,
+				F1B1DF762BC19FC4005E8F87 /* XCRemoteSwiftPackageReference "Queue" */,
 			);
 			productRefGroup = 8AC7A5CE26872C3E00C9CD98 /* Products */;
 			projectDirPath = "";
@@ -1439,6 +1443,14 @@
 				minimumVersion = 0.1.3;
 			};
 		};
+		F1B1DF762BC19FC4005E8F87 /* XCRemoteSwiftPackageReference "Queue" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mattmassicotte/Queue";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.4;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1530,6 +1542,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 27EDD623293B6DFD0028CCE4 /* XCRemoteSwiftPackageReference "SwiftUIX" */;
 			productName = SwiftUIX;
+		};
+		F1B1DF772BC19FC4005E8F87 /* Queue */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1B1DF762BC19FC4005E8F87 /* XCRemoteSwiftPackageReference "Queue" */;
+			productName = Queue;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/DanXi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DanXi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -55,6 +55,15 @@
       }
     },
     {
+      "identity" : "queue",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattmassicotte/Queue",
+      "state" : {
+        "revision" : "8d6f936097888f97011610ced40313655dc5948d",
+        "version" : "0.1.4"
+      }
+    },
+    {
       "identity" : "svgview",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/exyte/SVGView",

--- a/Shared/Resources/license.json
+++ b/Shared/Resources/license.json
@@ -73,5 +73,10 @@
         "name": "SwiftUI Introspect",
         "link": "https://github.com/siteline/SwiftUI-Introspect",
         "license": "Copyright 2019 Timber Software"
+    },
+    {
+        "name": "Queue",
+        "link": "https://github.com/mattmassicotte/Queue",
+        "license": "BSD-3-Clause license"
     }
 ]


### PR DESCRIPTION
This PR contains two commits. The first commit serializes all operation involving JWT tokens and fixes #31 in a simple but less ideal way. The second commit attempts to allow concurrent operations using a concurrent queue and barrier operations. I will explain the second commit below.

The main idea is to establish a concurrent queue so that all operations run concurrently until a "barrier" operation, which blocks all operation after it from executing until the barrier itself is completed. Assuming the JWT token is valid, all operations should run concurrently because no barrier is added to the queue. If, at some point, the JWT expires, the first operation that detects this will add a barrier operation to the queue that refreshes the token. Many such barriers may be added because all operations running concurrently will add such a barrier. Because all refresh operations are barrier operations, they will run serially. The first refresh operation will refresh the JWT and update it. All refresh operations that follow will detect that the JWT has been updated by someone else and thus do nothing. After all barriers have been completed, the queue restores normal operation and re-sends all requests that failed.

Please review carefully as this code has not been battle-tested and possibly contains bugs. Closes #31 .