### PR TITLE
fix: app loses state between entering background

### DIFF
--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -11,15 +11,12 @@ struct ContentView: View {
     @StateObject private var navigator = AppNavigator()
     
     var body: some View {
-        Group {
-            if horizontalSizeClass == .compact {
-                TabNavigation(screen: $model.screen)
-                    .environmentObject(navigator)
-            } else {
-                SplitNavigation(screen: $model.screen)
-                    .environmentObject(navigator)
-            }
+        WideScreenReader {
+            SplitNavigation(screen: $model.screen)
+        } narrow: {
+            TabNavigation(screen: $model.screen)
         }
+        .environmentObject(navigator)
         .environmentObject(model)
         .onOpenURL { url in
             model.openURL(url)

--- a/Shared/DanXiApp.swift
+++ b/Shared/DanXiApp.swift
@@ -18,5 +18,3 @@ struct DanXiApp: App {
         }
     }
 }
-
-

--- a/View Utils/Navigation/WideScreenReader.swift
+++ b/View Utils/Navigation/WideScreenReader.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/**
+ A view that switch between compact and regular view while preventing app to lose state.
+ 
+ When the app enters background, the `horizontalSizeClass` will change between `.regular` and `.compact`.
+ If the view directly depend on `horizontalSizeClass`, this change causes the view to recompute and lose state.
+ This wrapper is a workaround.
+ */
+public struct WideScreenReader<Wide: View, Narrow: View>: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.scenePhase) private var scenePhase
+    
+    @StateObject private var model = WideScreenReaderModel()
+    
+    private var actualHorizontalSizeClass: UserInterfaceSizeClass? {
+        if scenePhase == .active {
+            model.storedHorizontalSizeClass = horizontalSizeClass
+            return horizontalSizeClass
+        } else {
+            return model.storedHorizontalSizeClass
+        }
+    }
+    
+    private let wide: () -> Wide
+    private let narrow: () -> Narrow
+    
+    public init(wide: @escaping () -> Wide, narrow: @escaping () -> Narrow) {
+        self.wide = wide
+        self.narrow = narrow
+    }
+    
+    public var body: some View {
+        if actualHorizontalSizeClass == .compact {
+            narrow()
+        } else {
+            wide()
+        }
+    }
+}
+
+private class WideScreenReaderModel: ObservableObject {
+    var storedHorizontalSizeClass: UserInterfaceSizeClass? = nil
+}


### PR DESCRIPTION
This commit is trying to fix issue #217.

Known bugs: UI may flicker when user switch between compact and wide screen.

Please test this on all platforms (iPhone, iPad, Mac) before approving.