### PR TITLE
fix: SFSafari should not try to open unsupported links

### DIFF
--- a/DanXiUI/Utils/SafariView.swift
+++ b/DanXiUI/Utils/SafariView.swift
@@ -43,7 +43,7 @@ private struct SafariWrapper<Content: View>: View {
         content()
             #if !targetEnvironment(macCatalyst)
             .environment(\.openURL, OpenURLAction { url in
-                if shouldOpenInBrowser {
+                if shouldOpenInBrowser || !["http", "https"].contains(url.scheme?.lowercased() ?? "") {
                     UIApplication.shared.open(url)
                 } else {
                     safariURL = url


### PR DESCRIPTION
Whether this works or not has not yet been tested.