### PR TITLE
fix: webvpn state when returning from background by switching to SwiftUI lifecycle control

### DIFF
--- a/DanXi Kit/Utils/Proxy.swift
+++ b/DanXi Kit/Utils/Proxy.swift
@@ -177,5 +177,5 @@ extension WebVPNError: LocalizedError {
 public class ProxySettings: ObservableObject {
     public static let shared = ProxySettings()
     
-    @AppStorage("enable-proxy") public var enableProxy = true
+    @AppStorage("enable-webvpn") public var enableProxy = true
 }

--- a/Shared/DanXiApp.swift
+++ b/Shared/DanXiApp.swift
@@ -23,7 +23,7 @@ struct DanXiApp: App {
                         if oldPhase == .background {
                             // Application is resuming from background
                             // The two other states, active and inactive, should both be treated as running in foreground
-                            ProxySettings.shared.enableProxy = false
+                            Proxy.shared.outsideCampus = false
                             // TODO: refresh outdated homescreen cards
                         }
                     }

--- a/Shared/DanXiApp.swift
+++ b/Shared/DanXiApp.swift
@@ -1,20 +1,38 @@
 import SwiftUI
 import DanXiUI
+import DanXiKit
 import ViewUtils
 import Utils
 
 @main
 struct DanXiApp: App {
+    @Environment(\.scenePhase) var scenePhase
+    
     #if os(iOS)
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
     #endif
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .task(priority: .background) {
-                    ConfigurationCenter.initialFetch()
-                }
+            if #available(iOS 17.0, *) {
+                ContentView()
+                    .task(priority: .background) {
+                        ConfigurationCenter.initialFetch()
+                    }
+                    .onChange(of: scenePhase) { oldPhase, newPhase in
+                        if oldPhase == .background {
+                            // Application is resuming from background
+                            // The two other states, active and inactive, should both be treated as running in foreground
+                            ProxySettings.shared.enableProxy = false
+                            // TODO: refresh outdated homescreen cards
+                        }
+                    }
+            } else {
+                ContentView()
+                    .task(priority: .background) {
+                        ConfigurationCenter.initialFetch()
+                    }
+            }
         }
     }
 }

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -42,10 +42,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         return true
     }
     
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        ProxySettings.shared.enableProxy = false
-    }
-    
     // MARK: - Notification
     
     func application(_ application: UIApplication,


### PR DESCRIPTION
**IMPORTANT:** This has not been tested on iOS yet. Please test this on iOS simulator before approving.

Expected behavior:
WebVPN state should reset to disabled after app returns from background.