### PR TITLE
feat: sync user credentials using icloud

### DIFF
--- a/DanXi Kit/Authentication/CredentialStore.swift
+++ b/DanXi Kit/Authentication/CredentialStore.swift
@@ -17,6 +17,7 @@ public class CredentialStore {
     
     init() {
         let keychain = Keychain(service: "com.fduhole.danxi")
+            .synchronizable(true)
         self.keychain = keychain
         
         if let data = keychain[data: "token"],

--- a/Fudan Kit/CredentialStore.swift
+++ b/Fudan Kit/CredentialStore.swift
@@ -21,6 +21,7 @@ public class CredentialStore {
     
     init() {
         let keychain = Keychain(service: "com.fduhole.fdutools", accessGroup: "group.com.fduhole.danxi")
+            .synchronizable(true)
         self.keychain = keychain
         self.username = keychain["username"]
         self.password = keychain["password"]


### PR DESCRIPTION
This PR marks the Keychain as iCloud sync-able. This should eliminate the need to login multiple times if the user has different devices, and prepare for the upcoming watchOS version. 

Regarding watchOS preparations, we can't rely on iCloud keychain to log users in, since not all users have iCloud keychain turned on, but it improves the overall reliability. Traditionally, transferring user credentials via WatchConnectivity often prove unreliable, as the transfer requires a session to be active (both ends need to have the app open?). Having iCloud keychain eases this requirement for most users. For users that don't have iCloud keychain, they can fallback to WatchConnectivity transfer or manual login.

This however, may have unexpected implications. Do users need to sign in to different accounts on different devices? (Presumably not, as our terms do not permit one user to have multiple accounts) Do we need a toggle to turn it off? 

This change is open to discussion.