### PR TITLE
refactor: simplify login sheet structure and remove toolbar

### DIFF
--- a/DanXiUI/General/AuthenticationSheet.swift
+++ b/DanXiUI/General/AuthenticationSheet.swift
@@ -44,7 +44,10 @@ private struct LoginSheet: View {
     }
     
     var body: some View {
-        Form {
+        Sheet {
+            try await model.login()
+            authModel.done = true
+        } content: {
             FormTitle(title: String(localized: "DanXi Account", bundle: .module),
                       description: String(localized: "DanXi account is used to access community services such as Treehole and DanKe.", bundle: .module))
             
@@ -74,26 +77,9 @@ private struct LoginSheet: View {
                 .padding(.top)
             }
         }
-        .toolbar {
-            if style == .independent {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Cancel", bundle: .module)
-                    }
-                }
-            }
-            ToolbarItem(placement: .confirmationAction) {
-                AsyncButton {
-                    try await model.login()
-                    authModel.done = true
-                } label: {
-                    Text("Login", bundle: .module)
-                }
-                .disabled(!model.completed)
-            }
-        }
+        .completed(model.completed)
+        .submitText(String(localized: "Login", bundle: .module))
+        .sheetStyle(style)
     }
 }
 


### PR DESCRIPTION
Replaces the custom toolbar implementation in `AuthenticationSheet`'s `LoginSheet` with the reusable Sheet component from `View Utils` to add the standard loading indicator.