### PR TITLE
fix(holepage.swift): fix the 'show-all-floor' displaying bug on iOS26

### DIFF
--- a/DanXiUI/Forum/Pages/HolePage.swift
+++ b/DanXiUI/Forum/Pages/HolePage.swift
@@ -116,15 +116,27 @@ struct HolePage: View {
                 }
                 
                 ToolbarItem(placement: .bottomBar) {
-                    bottomBar
+                    if #available(iOS 26.0, *) {
+                        // bottomBar is covered by tabBar in iOS 26+
+                        // using .overlay to generate a show-all-floor button
+                    }
+                    else {
+                        bottomBar
+                    }
                 }
             }
             .overlay(alignment: .bottom) {
-                if let originalFloor = model.scrollFrom {
-                    ReturnCapsule(originalFloor: originalFloor)
-                        .id(originalFloor.id)
-                        .padding(.bottom, 20)
-                }
+                VStack(spacing: 0) {
+                        if let originalFloor = model.scrollFrom {
+                            ReturnCapsule(originalFloor: originalFloor)
+                                .id(originalFloor.id)
+                                .padding(.bottom, 20)
+                        }
+                        
+                        if #available(iOS 26.0, *) {
+                            bottomButton
+                        }
+                    }
             }
             .environmentObject(model)
             .task {
@@ -334,6 +346,34 @@ struct HolePage: View {
                         .labelStyle(.titleAndIcon)
                 }
             }
+        }
+    }
+    
+    @ViewBuilder
+    private var bottomButton: some View {
+        // For iOS26 + where bottomBar is covered by tabBar
+        // see returnCapsule for the style of this button
+        if model.filterOption != .all && model.filterOption != .posterOnly {
+            Button {
+                withAnimation {
+                    model.filterOption = .all
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "bubble.left.and.bubble.right")
+                    Text("Show All Floors", bundle: .module)
+                    .font(.system(size: 16))
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 10)
+            .background {
+                Capsule(style: .continuous)
+                    .fill(.thickMaterial)
+                    .shadow(.drop(radius: 12))
+                    
+            }
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .padding(.horizontal, 18).padding(.bottom, 20)
         }
     }
 }


### PR DESCRIPTION
On iOS18 or lower, a bottomBar was used for holding the show-all-floors button, which is stacked on the tabBar. On iOS 26, the tabBar is floating and it covered the bottomBar.So a capsule button is introduced as the show-all-floors button. The style of the button is consistent with the returnCapsule.

fix #538
<img width="230" height="188" alt="截屏2025-10-10 18 57 54" src="https://github.com/user-attachments/assets/ef87bcc0-2c84-4be4-854e-ad09f9af9d38" />
