### PR TITLE
fix: restore paste functionality and UI on Mac Catalyst

### DIFF
--- a/DanXiUI/General/KeyAdminSection.swift
+++ b/DanXiUI/General/KeyAdminSection.swift
@@ -105,9 +105,25 @@ struct KeyAdminSection: View {
                 
                 HStack {
                     Spacer()
+                    // on MacOS, PasteButton does not work, use UIPasteBoard
+                    #if targetEnvironment(macCatalyst)
+                    Button {
+                        if let string = UIPasteboard.general.string {
+                            plaintext = string
+                        }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "doc.on.clipboard")
+                            Text("Paste", bundle: .module)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    #else
+                    // On iOS, use PasteButton
                     PasteButton(payloadType: String.self) { strings in
                         plaintext = strings.first
                     }
+                    #endif
                     Spacer()
                 }
             }

--- a/DanXiUI/Resouces/Localizable.xcstrings
+++ b/DanXiUI/Resouces/Localizable.xcstrings
@@ -2365,6 +2365,17 @@
         }
       }
     },
+    "Paste" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴"
+          }
+        }
+      }
+    },
     "Paste Decrypted Plaintext Here" : {
       "localizations" : {
         "zh-Hans" : {


### PR DESCRIPTION
- Fixed a critical issue where PasteButton was non-functional on macOS.
- Replaced incompatible PasteButton with a custom Button using targetEnvironment(macCatalyst).
- Manually bridged UIPasteboard for clipboard access.
<img width="590" height="614" alt="截屏2025-12-21 16 19 40" src="https://github.com/user-attachments/assets/b371d7a9-0aeb-4719-a18f-649c01fa47eb" />
