### PR TITLE
Fix report list not reloading when switching filter

### DIFF
--- a/DanXiUI/Forum/Model/ReportModel.swift
+++ b/DanXiUI/Forum/Model/ReportModel.swift
@@ -20,6 +20,7 @@ class ReportModel: ObservableObject {
     
     @Published var filterOption = FilterOption.notDealt {
         didSet {
+            endReached = false
             self.reports = []
         }
     }

--- a/DanXiUI/Forum/Pages/ReportPage.swift
+++ b/DanXiUI/Forum/Pages/ReportPage.swift
@@ -10,6 +10,7 @@ struct ReportPage: View {
             AsyncCollection(model.reports, endReached: model.endReached, action: model.loadMoreReports) { report in
                 ReportView(report: report)
             }
+            .id(model.filterOption)
         }
         .environmentObject(model)
         .listStyle(.inset)


### PR DESCRIPTION
## Problem
For admin users, when there are no "Not Dealt" reports, switching to "Dealt" could show an empty list and fail to load handled reports.

## Root Cause
`ReportModel.filterOption` only cleared `reports`, but the list loading flow in `AsyncCollection` was not reliably retriggered in the empty-to-empty transition.

## Fix
- Reset `endReached` when `filterOption` changes.
- Rebuild `AsyncCollection` on filter change via `.id(model.filterOption)` in `ReportPage`.

## Verification
- Open Reports Management as an admin account.
- Ensure "Not Dealt" is empty.
- Switch to "Dealt" and "All Reports".
- Lists now load correctly instead of staying empty.