### PR TITLE
修复 StickerStore 多窗口重复初始化竞争

### DIFF
--- a/DanXiUI/Forum/Store/StickerStore.swift
+++ b/DanXiUI/Forum/Store/StickerStore.swift
@@ -9,6 +9,9 @@ class StickerStore: ObservableObject {
     var stickerSet: Set<String>
     var stickerImage: [String: LoadedImage]
     
+    var initialized = false
+    private var initializingTask: Task<Void, Error>?
+    
     init() {
         stickers = []
         stickerImage = [:]
@@ -16,25 +19,69 @@ class StickerStore: ObservableObject {
     }
     
     func initialize() async throws {
-        if ConfigurationCenter.configuration.stickers.isEmpty {
-            try await ConfigurationCenter.refresh()
+        guard let task = await initializationTask() else { return }
+        try await task.value
+    }
+    
+    @MainActor
+    private func initializationTask() -> Task<Void, Error>? {
+        if initialized {
+            return nil
         }
         
-        self.stickers = ConfigurationCenter.configuration.stickers
-        self.stickerSet = Set(stickers.map(\.id))
+        if let initializingTask {
+            return initializingTask
+        }
         
-        for sticker in stickers {
-            do {
-                let loadedImage = try await retrieveImage(sticker: sticker, scale: 0.4)
-                stickerImage[sticker.id] = loadedImage
-            } catch _ as URLError {
-                continue // ignore network error, sticker loading failed should not be fatal
+        let task = Task {
+            try await loadStickers()
+        }
+        initializingTask = task
+        return task
+    }
+    
+    private func loadStickers() async throws {
+        do {
+            if ConfigurationCenter.configuration.stickers.isEmpty {
+                try await ConfigurationCenter.refresh()
             }
+            
+            let stickers = ConfigurationCenter.configuration.stickers
+            var stickerImage: [String: LoadedImage] = [:]
+            stickerImage.reserveCapacity(stickers.count)
+            
+            for sticker in stickers {
+                do {
+                    let loadedImage = try await retrieveImage(sticker: sticker, scale: 0.4)
+                    stickerImage[sticker.id] = loadedImage
+                } catch _ as URLError {
+                    continue // ignore network error, sticker loading failed should not be fatal
+                }
+            }
+            
+            await set(stickers: stickers, stickerImage: stickerImage)
+            
+            Task(priority: .background) {
+                try? clearUnunsed(stickers: stickers)
+            }
+        } catch {
+            await resetInitialization()
+            throw error
         }
-        
-        Task {
-            try clearUnunsed(stickers: stickers)
-        }
+    }
+    
+    @MainActor
+    private func set(stickers: [Sticker], stickerImage: [String: LoadedImage]) {
+        self.stickers = stickers
+        self.stickerSet = Set(stickers.map(\.id))
+        self.stickerImage = stickerImage
+        initialized = true
+        initializingTask = nil
+    }
+    
+    @MainActor
+    private func resetInitialization() {
+        initializingTask = nil
     }
     
     private func retrieveImage(sticker: Sticker, scale: CGFloat = 1.0) async throws -> LoadedImage {


### PR DESCRIPTION
在 iPad 和 macOS 的多窗口场景下，应用内可能同时存在多个树洞主页。每个树洞主页都会走初始加载流程，因此 StickerStore.initialize() 可能被重复触发。

重复初始化时，多个异步任务可能并发执行。原实现会在加载每个表情包后直接写入共享的 stickerImage Dictionary，多个初始化任务同时写入时会产生 Dictionary 并发写入竞争，并可能在 Dictionary.setValue 或释放 LoadedImage 时崩溃。

这次修复给 StickerStore 增加了 initialized 和 initializingTask。已经初始化完成时后续调用直接返回；初始化进行中时后续调用等待同一个任务，不再启动新的加载流程。表情图加载过程中先写入局部字典，加载完成后通过 @MainActor 的 set 方法一次性写入 stickers、stickerSet 和 stickerImage，避免逐项切换到 MainActor，也避免后台任务直接修改共享 Dictionary。