### PR TITLE
fix: persist the WebVPN session cookie to stop the forum freezing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,7 @@ iOSInjectionProject/
 /.idea
 .vscode/
 
+# Local notes
+*.local.md
+
 **/Package.resolved

--- a/Fudan Kit/Authentication/WebVPNCookieStore.swift
+++ b/Fudan Kit/Authentication/WebVPNCookieStore.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Preserves WebVPN session cookies across app launches.
+public enum WebVPNCookieStore {
+    private static let domain = "webvpn.fudan.edu.cn"
+    private static let storageKey = "webvpn-cookies"
+
+    public static func save() {
+        let cookies = (HTTPCookieStorage.shared.cookies ?? [])
+            .filter { $0.domain == domain || $0.domain == ".\(domain)" }
+            .map(PersistedCookie.init)
+
+        if let data = try? JSONEncoder().encode(cookies) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    public static func restore() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let cookies = try? JSONDecoder().decode([PersistedCookie].self, from: data) else {
+            return
+        }
+
+        cookies.compactMap(\.cookie).forEach(HTTPCookieStorage.shared.setCookie)
+    }
+
+    public static func clear() {
+        UserDefaults.standard.removeObject(forKey: storageKey)
+    }
+}
+
+private struct PersistedCookie: Codable {
+    let name: String
+    let value: String
+    let domain: String
+    let path: String
+    let expiresDate: Date?
+    let isSecure: Bool
+
+    init(_ cookie: HTTPCookie) {
+        name = cookie.name
+        value = cookie.value
+        domain = cookie.domain
+        path = cookie.path
+        expiresDate = cookie.expiresDate
+        isSecure = cookie.isSecure
+    }
+
+    var cookie: HTTPCookie? {
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: path,
+        ]
+        if let expiresDate {
+            properties[.expires] = expiresDate
+        }
+        if isSecure {
+            properties[.secure] = "TRUE"
+        }
+        return HTTPCookie(properties: properties)
+    }
+}

--- a/Fudan Kit/CampusModel.swift
+++ b/Fudan Kit/CampusModel.swift
@@ -65,6 +65,7 @@ public class CampusModel: ObservableObject {
         
         // remove all cookies
         HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
+        WebVPNCookieStore.clear()
         
         let clearableStores = self.clearableStores
         // clear cache

--- a/Shared/DanXiApp.swift
+++ b/Shared/DanXiApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FudanKit
 import DanXiUI
 import DanXiKit
 import ViewUtils
@@ -12,7 +13,11 @@ struct DanXiApp: App {
     #if os(iOS)
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
     #endif
-    
+
+    init() {
+        WebVPNCookieStore.restore()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -27,6 +32,7 @@ struct DanXiApp: App {
                 .onChange(of: scenePhase) { newPhase in
                     if newPhase == .background {
                         Proxy.shared.outsideCampus = false
+                        WebVPNCookieStore.save()
                     }
                 }
         }


### PR DESCRIPTION
iOS 不持久化 session cookie，App 的 session cookie 只活在进程内存里, 是 cookie 规范的语义 ("session"的定义就是"浏览器会话结束即失效",对 App 来说就是进程终止)。苹果没有任何官方 API 能让 session cookie 跨启动持久化。

为了使得 WebVPN 不需要每次冷启动都花 60 秒登录，需要自行持久化 cookie。